### PR TITLE
Enhance the application tests to check row controller identity

### DIFF
--- a/ApplicationTests/ApplicationTests WatchKit App/Base.lproj/Interface.storyboard
+++ b/ApplicationTests/ApplicationTests WatchKit App/Base.lproj/Interface.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="6751" systemVersion="14C109" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="AgC-eL-Hgc">
+<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="AgC-eL-Hgc">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="3737"/>
     </dependencies>
     <scenes>
@@ -12,7 +12,7 @@
                     <items>
                         <table alignment="left" id="hnV-JC-d50">
                             <items>
-                                <tableRow identifier="HeaderRow" id="TyY-lz-Ehs">
+                                <tableRow identifier="HeaderRow" id="TyY-lz-Ehs" customClass="HeaderRowController">
                                     <group key="rootItem" width="1" alignment="left" spacing="0.0" id="tJZ-AE-MJL">
                                         <items>
                                             <label alignment="left" verticalAlignment="center" text="Header" id="anI-MR-FJ7">
@@ -21,7 +21,7 @@
                                         </items>
                                     </group>
                                 </tableRow>
-                                <tableRow identifier="SectionRow" id="sIB-Pa-GoT">
+                                <tableRow identifier="SectionRow" id="sIB-Pa-GoT" customClass="SectionRowController">
                                     <group key="rootItem" width="1" alignment="left" spacing="5" id="tjD-qD-tjY">
                                         <items>
                                             <label alignment="left" verticalAlignment="center" text="Section" id="kL5-ip-FAE">
@@ -29,11 +29,8 @@
                                             </label>
                                         </items>
                                     </group>
-                                    <connections>
-                                        <outlet property="textLabel" destination="kL5-ip-FAE" id="A0D-wh-J2g"/>
-                                    </connections>
                                 </tableRow>
-                                <tableRow identifier="Row" id="6yx-WG-6YO">
+                                <tableRow identifier="Row" id="6yx-WG-6YO" customClass="RowController">
                                     <group key="rootItem" width="1" alignment="left" id="0Uu-zT-7Kz">
                                         <items>
                                             <label alignment="left" verticalAlignment="center" text="Row" id="9ik-AE-cg7">
@@ -41,11 +38,8 @@
                                             </label>
                                         </items>
                                     </group>
-                                    <connections>
-                                        <outlet property="textLabel" destination="9ik-AE-cg7" id="qHf-58-ZRz"/>
-                                    </connections>
                                 </tableRow>
-                                <tableRow identifier="FooterRow" id="IOS-Eq-Bhd">
+                                <tableRow identifier="FooterRow" id="IOS-Eq-Bhd" customClass="FooterRowController">
                                     <group key="rootItem" width="1" alignment="left" id="Sqg-j5-IbL">
                                         <items>
                                             <label alignment="left" verticalAlignment="center" text="Footer" id="5AZ-5k-88s">

--- a/ApplicationTests/ApplicationTests WatchKit Extension/FooterRowController.h
+++ b/ApplicationTests/ApplicationTests WatchKit Extension/FooterRowController.h
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface FooterRowController : NSObject
+
+@end

--- a/ApplicationTests/ApplicationTests WatchKit Extension/FooterRowController.m
+++ b/ApplicationTests/ApplicationTests WatchKit Extension/FooterRowController.m
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "FooterRowController.h"
+
+@implementation FooterRowController
+
+@end

--- a/ApplicationTests/ApplicationTests WatchKit Extension/HeaderRowController.h
+++ b/ApplicationTests/ApplicationTests WatchKit Extension/HeaderRowController.h
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface HeaderRowController : NSObject
+
+@end

--- a/ApplicationTests/ApplicationTests WatchKit Extension/HeaderRowController.m
+++ b/ApplicationTests/ApplicationTests WatchKit Extension/HeaderRowController.m
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "HeaderRowController.h"
+
+@implementation HeaderRowController
+
+@end

--- a/ApplicationTests/ApplicationTests WatchKit Extension/InterfaceController.m
+++ b/ApplicationTests/ApplicationTests WatchKit Extension/InterfaceController.m
@@ -9,6 +9,10 @@
  */
 
 #import "InterfaceController.h"
+#import "HeaderRowController.h"
+#import "SectionRowController.h"
+#import "RowController.h"
+#import "FooterRowController.h"
 
 #import <IGInterfaceDataTable/IGInterfaceDataTable.h>
 
@@ -38,21 +42,25 @@
   self.showsHeader = YES;
   [self.table reloadData];
   NSAssert([self.table numberOfRows] == 1, @"Table did not display the header");
+  NSAssert([[self.table rowControllerAtIndex:0] isKindOfClass:[HeaderRowController class]], @"Header-only table does not have a HeaderRowController");
 
   // Test table footer
   self.showsFooter = YES;
   [self.table reloadData];
   NSAssert([self.table numberOfRows] == 2, @"Table did not display the footer");
+  NSAssert([[self.table rowControllerAtIndex:1] isKindOfClass:[FooterRowController class]], @"Expected footer row is not a FooterRowController");
 
   // Test table rows
   self.sections = [@[@1] mutableCopy];
   [self.table reloadData];
   NSAssert([self.table numberOfRows] == 3, @"Table did not display a row");
+  NSAssert([[self.table rowControllerAtIndex:1] isKindOfClass:[RowController class]], @"Expected data row is not a RowController");
 
   // Test table section headers
   self.showsSections = YES;
   [self.table reloadData];
   NSAssert([self.table numberOfRows] == 4, @"Table did not display a section header");
+  NSAssert([[self.table rowControllerAtIndex:1] isKindOfClass:[SectionRowController class]], @"Expected section header is not a SectionRowController");
 
   // Test complex table with header, footer, rows, and section headers
   self.sections = [@[@1, @2, @3] mutableCopy];
@@ -66,6 +74,7 @@
   // Test remove sections
   [self.table removeSections:[NSIndexSet indexSetWithIndex:2]];
   NSAssert([self.table numberOfRows] == 6, @"Removing a section did not update the table rows correctly");
+  NSAssert([[self.table rowControllerAtIndex:0] isKindOfClass:[HeaderRowController class]], @"First row is no longer a table header");
 
   // Test inserting a row
   [self.table insertRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:0 inSection:1]] withRowType:@"Row"];

--- a/ApplicationTests/ApplicationTests WatchKit Extension/RowController.h
+++ b/ApplicationTests/ApplicationTests WatchKit Extension/RowController.h
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface RowController : NSObject
+
+@end

--- a/ApplicationTests/ApplicationTests WatchKit Extension/RowController.m
+++ b/ApplicationTests/ApplicationTests WatchKit Extension/RowController.m
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "RowController.h"
+
+@implementation RowController
+
+@end

--- a/ApplicationTests/ApplicationTests WatchKit Extension/SectionRowController.h
+++ b/ApplicationTests/ApplicationTests WatchKit Extension/SectionRowController.h
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface SectionRowController : NSObject
+
+@end

--- a/ApplicationTests/ApplicationTests WatchKit Extension/SectionRowController.m
+++ b/ApplicationTests/ApplicationTests WatchKit Extension/SectionRowController.m
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "SectionRowController.h"
+
+@implementation SectionRowController
+
+@end

--- a/ApplicationTests/ApplicationTests.xcodeproj/project.pbxproj
+++ b/ApplicationTests/ApplicationTests.xcodeproj/project.pbxproj
@@ -19,6 +19,10 @@
 		2997A5281AB0B9CC008CF149 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2997A5271AB0B9CC008CF149 /* Images.xcassets */; };
 		2997A52B1AB0B9CC008CF149 /* ApplicationTests WatchKit Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 2997A50E1AB0B9CC008CF149 /* ApplicationTests WatchKit Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		5A2667A3C5B8110278FA1BA9 /* libPods-ApplicationTests WatchKit Extension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4207B02DE4418FB783566822 /* libPods-ApplicationTests WatchKit Extension.a */; };
+		781F4E2B1AE893D90007E2E3 /* HeaderRowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 781F4E2A1AE893D90007E2E3 /* HeaderRowController.m */; };
+		781F4E2E1AE893FA0007E2E3 /* SectionRowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 781F4E2D1AE893FA0007E2E3 /* SectionRowController.m */; };
+		781F4E321AE8942E0007E2E3 /* RowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 781F4E311AE8942E0007E2E3 /* RowController.m */; };
+		781F4E351AE894390007E2E3 /* FooterRowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 781F4E341AE894390007E2E3 /* FooterRowController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -73,6 +77,14 @@
 		4207B02DE4418FB783566822 /* libPods-ApplicationTests WatchKit Extension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ApplicationTests WatchKit Extension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		50B7CF739E5E26A5350F913A /* Pods-ApplicationTests WatchKit Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplicationTests WatchKit Extension.release.xcconfig"; path = "Pods/Target Support Files/Pods-ApplicationTests WatchKit Extension/Pods-ApplicationTests WatchKit Extension.release.xcconfig"; sourceTree = "<group>"; };
 		6AD0A20C7D2E6B6560BFA6A7 /* Pods-ApplicationTests WatchKit Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplicationTests WatchKit Extension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ApplicationTests WatchKit Extension/Pods-ApplicationTests WatchKit Extension.debug.xcconfig"; sourceTree = "<group>"; };
+		781F4E291AE893D90007E2E3 /* HeaderRowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HeaderRowController.h; sourceTree = "<group>"; };
+		781F4E2A1AE893D90007E2E3 /* HeaderRowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HeaderRowController.m; sourceTree = "<group>"; };
+		781F4E2C1AE893FA0007E2E3 /* SectionRowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SectionRowController.h; sourceTree = "<group>"; };
+		781F4E2D1AE893FA0007E2E3 /* SectionRowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SectionRowController.m; sourceTree = "<group>"; };
+		781F4E301AE8942E0007E2E3 /* RowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RowController.h; sourceTree = "<group>"; };
+		781F4E311AE8942E0007E2E3 /* RowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RowController.m; sourceTree = "<group>"; };
+		781F4E331AE894390007E2E3 /* FooterRowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FooterRowController.h; sourceTree = "<group>"; };
+		781F4E341AE894390007E2E3 /* FooterRowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FooterRowController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -143,6 +155,7 @@
 			children = (
 				2997A5131AB0B9CC008CF149 /* InterfaceController.h */,
 				2997A5141AB0B9CC008CF149 /* InterfaceController.m */,
+				781F4E2F1AE894080007E2E3 /* Row Controllers */,
 				2997A5191AB0B9CC008CF149 /* Images.xcassets */,
 				2997A5101AB0B9CC008CF149 /* Supporting Files */,
 			);
@@ -182,6 +195,21 @@
 				50B7CF739E5E26A5350F913A /* Pods-ApplicationTests WatchKit Extension.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		781F4E2F1AE894080007E2E3 /* Row Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				781F4E291AE893D90007E2E3 /* HeaderRowController.h */,
+				781F4E2A1AE893D90007E2E3 /* HeaderRowController.m */,
+				781F4E2C1AE893FA0007E2E3 /* SectionRowController.h */,
+				781F4E2D1AE893FA0007E2E3 /* SectionRowController.m */,
+				781F4E301AE8942E0007E2E3 /* RowController.h */,
+				781F4E311AE8942E0007E2E3 /* RowController.m */,
+				781F4E331AE894390007E2E3 /* FooterRowController.h */,
+				781F4E341AE894390007E2E3 /* FooterRowController.m */,
+			);
+			name = "Row Controllers";
 			sourceTree = "<group>";
 		};
 		9733A53465B7C8A1B0AE544A /* Frameworks */ = {
@@ -368,6 +396,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				2997A5151AB0B9CC008CF149 /* InterfaceController.m in Sources */,
+				781F4E2B1AE893D90007E2E3 /* HeaderRowController.m in Sources */,
+				781F4E321AE8942E0007E2E3 /* RowController.m in Sources */,
+				781F4E351AE894390007E2E3 /* FooterRowController.m in Sources */,
+				781F4E2E1AE893FA0007E2E3 /* SectionRowController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
I found a bug in `removeSections:` (pull request to come) and wanted to write a failing test first. I think you're sticking with this method of testing for now, at least until unit tests come to WatchKit.

These commits add row controller subclasses for each row type. That way, the tests can grab the row controller and check their class identity. The old tests only tested the overall *number* of rows, but these tests will make sure the correct *kind* of row is in the expected spot.