### PR TITLE
When deleting an entire section, start deleting rows from the start of that section

### DIFF
--- a/IGInterfaceDataTable/WKInterfaceTable+IGInterfaceDataTable.m
+++ b/IGInterfaceDataTable/WKInterfaceTable+IGInterfaceDataTable.m
@@ -312,7 +312,7 @@
         NSArray *subRowData = [originalRowSectionData subarrayWithRange:NSMakeRange(subArrayStart, count - subArrayStart)];
         [subRowData enumerateObjectsUsingBlock:^(IGTableRowData *row, NSUInteger idx, BOOL *stop2) {
           if (row.section == section) {
-            [rowIndexes addIndex:idx];
+            [rowIndexes addIndex:subArrayStart + idx];
           } else {
             *stop2 = YES;
           }


### PR DESCRIPTION
When deleting an entire section, the old behavior will delete rows from the top of the table at index 0.

The total number of rows deleted is correct, but the correct behavior should be to start deleting at `subArrayStart` rather than at 0.