### PR TITLE
Frc issues

### DIFF
--- a/IGInterfaceDataTable/WKInterfaceTable+IGInterfaceDataTable.h
+++ b/IGInterfaceDataTable/WKInterfaceTable+IGInterfaceDataTable.h
@@ -29,7 +29,7 @@
  * @param table The table requesting the information.
  * @param indexPath An index path locating a row in the table.
  * @return An identifier representing a row controller in the table.
- * @discussion You may return different identifiers based on your application's requirements. Identifiers must be 
+ * @discussion You may return different identifiers based on your application's requirements. Identifiers must be
  * established in the storyboard that the table was initialized from. The identifier returned must not be nil.
  */
 - (NSString *)table:(WKInterfaceTable *)table rowIdentifierAtIndexPath:(NSIndexPath *)indexPath;
@@ -69,7 +69,7 @@
  * Asks the data source to configure a header row controller.
  * @param table The table requesting the information.
  * @param headerController The row controller created by the table.
- * @discussion The class of the headerController will correspond to the class of the row controller configured in 
+ * @discussion The class of the headerController will correspond to the class of the row controller configured in
  * your storyboard with the identifier returned by -headerIdentifierForTable:. If -headerIdentifierForTable: is not
  * implemented, this method is never called.
  */
@@ -113,7 +113,7 @@
 
 @property (nonatomic, weak) id<IGInterfaceTableDataSource> ig_dataSource;
 
-/** 
+/**
  * Reload the table
  * @discussion Reloads all row controllers for the table, including rows, headers, footers, and section headers.
  */
@@ -122,7 +122,7 @@
 
 /** @name Convenience */
 
-/** 
+/**
  * Convert an index for a flat array of row controllers to an indexPath.
  * @param rowIndex An index of a row controller in the table.
  * @return An index path for a row or nil.
@@ -144,14 +144,14 @@
 /** @name Headers & Footers */
 
 /**
- * Get the row controller for the table header. If @p-headerIdentifierForTable: is not implemented, this will return 
+ * Get the row controller for the table header. If @p-headerIdentifierForTable: is not implemented, this will return
  * nil.
  * @return The row controller for the header or nil.
  */
 - (NSObject *)headerController;
 
 /**
- * Get the row controller for the table footer. If @p-footerIdentifierForTable: is not implemented, this will return 
+ * Get the row controller for the table footer. If @p-footerIdentifierForTable: is not implemented, this will return
  * nil.
  * @return The row controller for the footer or nil.
  */
@@ -176,6 +176,23 @@
 
 
 /** @name Editing */
+
+/**
+ * Starts the updates to the table, data is not inserted normally here.
+ */
+- (void)beginUpdates;
+
+/**
+ * Stops the updates to the table to allow normal inserts
+ */
+- (void)endUpdates;
+
+/**
+ * Update a row in the table for a given index path.
+ * @param indexPath The index path of the row to update
+ * @discussion This will update the row at the specifed indexPath. It does it by calling the configure row and the correct index path on the delegate.
+ */
+- (void)updateRowWithIndexPath:(NSIndexPath *)indexPath;
 
 /**
  * Insert new table sections.


### PR DESCRIPTION
This adds support beginUpdating and endUpdating like a regular UITableView. This is needed because FRC tends to insert multiple objects out of order.

This also adds support for the AppExtensionAPI which is needed for WatchKit Apps. 
